### PR TITLE
changed type from list to str, removed listType option

### DIFF
--- a/transforms/case_transform/case_transform.json
+++ b/transforms/case_transform/case_transform.json
@@ -14,7 +14,7 @@
     {
       "name": "case",
       "displayName": "Case",
-      "type": "list",
+      "type": "str",
       "isOptional": false,
       "description": "Transform to lowercase or uppercase",
       "listOptions": [
@@ -26,8 +26,7 @@
           "value": "lowercase",
           "label": "Lowercase"
         }
-      ],
-      "listType": "str"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This passes just a string to the transform function so it passes parameter validation, and makes it so you can only pick one of the options instead of multiple, which would cause problems.